### PR TITLE
Utilizing app-version for image tag, updated metadata/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,34 @@ Nullstone Block standing up a worker as an AWS Fargate container service using E
   - Default: `256`
 - `service_memory: number`
   - Service Hard-Limit on Memory
-  - Measured in MB 
+  - Measured in MB
   - Default: `512`
+- `service_image: string`
+  - The docker image to deploy for this service.
+  - The version from the nullstone application will be used as the image tag.
+  - Default: `""` - An ECR repo will be created and used.
+- `service_env_vars: map(string)`
+  - Map of environment variables to inject into the service
 
 ## Outputs
 
+- `cluster_arn: string`
+  - Fargate Cluster ARN
 - `log_group_name`
   - Name of CloudWatch Log Group for service
-- `repo_name`
-  - Container Image Name for Service
-- `service_name`
+- `image_repo_name: string`
+  - Container Image Name for service
+- `image_repo_url: string`
+  - Container Image Repo URL for service
+- `image_pusher: object({name: string, access_key: string, secret_key: string)`
+  - An AWS user that has explicit permission to push to created ECR repo
+- `service_image: string`
+  - Full image URL for the service's docker image
+- `service_name: string`
   - Name of AWS ECS Service
-- `task_family`
-  - Name of single AWS ECS Task 
+- `service_id: string`
+  - AWS ECS Service ID
+- `task_family: string`
+  - Name of single AWS ECS Task
+- `service_security_group_id: string`
+  - Security Group ID for the service

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -9,6 +9,16 @@ terraform {
 
 data "ns_workspace" "this" {}
 
+data "ns_app_env" "this" {
+  app   = data.ns_workspace.this.block
+  stack = data.ns_workspace.this.stack
+  env   = data.ns_workspace.this.env
+}
+
+locals {
+  app_version = data.ns_app_env.this.version
+}
+
 data "ns_connection" "cluster" {
   name = "cluster"
   type = "cluster/aws-fargate"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "cluster_arn" {
+  value       = data.aws_ecs_cluster.cluster.arn
+  description = "string ||| "
+}
+
 output "log_group_name" {
   value       = aws_cloudwatch_log_group.this.name
   description = "string ||| "
@@ -23,6 +28,11 @@ output "image_pusher" {
   description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to push images."
 
   sensitive = true
+}
+
+output "service_image" {
+  value       = "${local.service_image}:${local.app_version}"
+  description = "string ||| "
 }
 
 output "service_name" {

--- a/repository.tf
+++ b/repository.tf
@@ -1,3 +1,9 @@
+locals {
+  // If someone specifies `var.service_image`, the ecr repository will not be created
+  // The following variable sets up the effective docker image
+  service_image = try(aws_ecr_repository.this[0].repository_url, var.service_image)
+}
+
 // This is a bit odd - we're creating a repository for every environment
 // We need to find a better way to do this
 resource "aws_ecr_repository" "this" {

--- a/task.tf
+++ b/task.tf
@@ -3,7 +3,7 @@ locals {
 
   container_definition = {
     name  = data.ns_workspace.this.block
-    image = "${aws_ecr_repository.this.repository_url}:${var.service_image_tag}"
+    image = "${local.service_image}:${local.app_version}"
     portMappings = [
       {
         protocol      = "tcp"

--- a/variables.tf
+++ b/variables.tf
@@ -4,23 +4,45 @@ variable "service_count" {
 }
 
 variable "service_cpu" {
-  type    = number
-  default = 256
+  type        = number
+  default     = 256
+  description = <<EOF
+The amount of CPU units to reserve for the service.
+1024 CPU units is roughly equivalent to 1 vCPU.
+This means the default of 256 CPU units is roughly .25 vCPUs.
+A vCPU is a virtualization of a physical CPU.
+EOF
 }
 
 variable "service_memory" {
-  type    = number
-  default = 512
+  type        = number
+  default     = 512
+  description = <<EOF
+The amount of memory to reserve and cap the service.
+If the service exceeds this amount, the service will be killed with exit code 127 representing "Out-of-memory".
+Memory is measured in MiB, or megabytes.
+This means the default is 512 MiB or 0.5 GiB.
+EOF
 }
 
-variable "service_image_tag" {
-  type    = string
-  default = "latest"
+variable "service_image" {
+  type        = string
+  default     = ""
+  description = <<EOF
+The docker image to deploy for this service.
+By default, this is blank, which means that an ECR repo is created and used.
+Use this variable to configure against docker hub, quay, etc.
+EOF
 }
 
 variable "service_env_vars" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = <<EOF
+The environment variables to inject into the service.
+These are typically used to configure a service per environment.
+It is dangerous to put sensitive information in this variable because they are not protected and could be unintentionally exposed.
+EOF
 }
 
 resource "random_string" "resource_suffix" {


### PR DESCRIPTION
This PR matches the changes made to github.com/nullstone-io/block-aws-fargate-service to utilize app version for the image tag.